### PR TITLE
Remove erroneous type casts

### DIFF
--- a/src/templates/_cosmetic.py
+++ b/src/templates/_cosmetic.py
@@ -3,7 +3,7 @@
 """
 # Standard Library Imports
 from functools import cached_property
-from typing import Optional, Callable, Union, cast
+from typing import Optional, Callable, Union
 
 # Third Party Imports
 from photoshop.api._artlayer import ArtLayer
@@ -142,7 +142,7 @@ class VectorNyxMod (NyxMod, VectorTemplate):
         if self.is_nyx:
             if layer := psd.getLayerSet(LAYERS.NYX):
                 return layer
-        return cast(super().background_group, Optional[LayerSet])
+        return super().background_group
 
 
 class CompanionMod (BaseTemplate):

--- a/src/templates/normal.py
+++ b/src/templates/normal.py
@@ -3,7 +3,7 @@
 """
 # Standard Library Imports
 from functools import cached_property
-from typing import Optional, Union, cast
+from typing import Optional, Union
 
 # Third Party Imports
 from photoshop.api import AnchorPosition, SolidColor
@@ -908,7 +908,7 @@ class UniversesBeyondTemplate(VectorTransformMod, VectorTemplate):
         """Optional[LayerSet]: No background for 'Colorless' cards."""
         if self.is_colorless:
             return
-        return cast(super().background_group, Optional[LayerSet])
+        return super().background_group
 
     """
     * Masks
@@ -1502,7 +1502,7 @@ class BorderlessVectorTemplate(
             return
         if self.is_textless and self.is_pt_enabled:
             return psd.getLayerSet(f'{LAYERS.PT_BOX} {LAYERS.TEXTLESS}')
-        return cast(super().pt_group, Optional[LayerSet])
+        return super().pt_group
 
     @cached_property
     def crown_group(self) -> LayerSet:
@@ -1514,7 +1514,7 @@ class BorderlessVectorTemplate(
         """Optional[LayerSet]: Textbox group if not a 'Textless' render."""
         if self.is_textless:
             return
-        return cast(super().textbox_group, Optional[LayerSet])
+        return super().textbox_group
 
     """
     * Text Layers


### PR DESCRIPTION
Removes casts that were breaking card rendering. `cast` takes a type and an object in that order but it was being called in the reverse order in the code. I removed the cast calls altogether as the typing was already inferred as `LayerSet | None` even without the cast, at least when using Pyright.