### PR TITLE
Fix Saga layout check

### DIFF
--- a/src/templates/saga.py
+++ b/src/templates/saga.py
@@ -46,6 +46,7 @@ class SagaMod (NormalTemplate):
     * Layout Checks
     """
 
+    @cached_property
     def is_layout_saga(self) -> bool:
         """Checks whether the card matches SagaLayout."""
         return isinstance(self.layout, SagaLayout)


### PR DESCRIPTION
In `SagaMod` class the `is_layout_saga` function is used as if it were a property, but since it is a function it always resolves as true. This pull request makes `ìs_layout_saga` a cached property to remedy the aforementioned discrepancy.