### PR TITLE
Fix leveler regex failure cases

### DIFF
--- a/src/enums/mtg.py
+++ b/src/enums/mtg.py
@@ -350,7 +350,7 @@ class CardTextPatterns:
     """Defined card data regex patterns."""
 
     # Rules Text - Special Card Types
-    LEVELER: re.Pattern = re.compile(r"(.*?)\nLEVEL (\d*-\d*)\n(\d*/\d*)\n(.*?)\nLEVEL (\d*\+)\n(\d*/\d*)\n(.*?)$")
+    LEVELER: re.Pattern = re.compile(r"(?s)(.?)\nLEVEL (\d-\d)\n(\d/\d)\n(.?)(?:\n|)LEVEL (\d+)\n(\d/\d)\n(.?)$", re.DOTALL)
     PROTOTYPE: re.Pattern = re.compile(r"Prototype (.+) [—\-] ([0-9]{0,2}/[0-9]{0,2}) \((.+)\)")
     PLANESWALKER: re.Pattern = re.compile(r"(^[^:]*$|^.*:.*$)", re.MULTILINE)
     CLASS: re.Pattern = re.compile(r"(.+?): Level (\d)\n(.+)")

--- a/src/enums/mtg.py
+++ b/src/enums/mtg.py
@@ -350,7 +350,7 @@ class CardTextPatterns:
     """Defined card data regex patterns."""
 
     # Rules Text - Special Card Types
-    LEVELER: re.Pattern = re.compile(r"(?s)(.?)\nLEVEL (\d-\d)\n(\d/\d)\n(.?)(?:\n|)LEVEL (\d+)\n(\d/\d)\n(.?)$", re.DOTALL)
+    LEVELER: re.Pattern = re.compile(r"(?s)(.*?)\nLEVEL (\d*-\d*)\n(\d*/\d*)\n(.*?)(?:\n|)LEVEL (\d*\+)\n(\d*/\d*)\n(.*?)$", re.DOTALL)
     PROTOTYPE: re.Pattern = re.compile(r"Prototype (.+) [—\-] ([0-9]{0,2}/[0-9]{0,2}) \((.+)\)")
     PLANESWALKER: re.Pattern = re.compile(r"(^[^:]*$|^.*:.*$)", re.MULTILINE)
     CLASS: re.Pattern = re.compile(r"(.+?): Level (\d)\n(.+)")

--- a/src/layouts.py
+++ b/src/layouts.py
@@ -1105,8 +1105,12 @@ class LevelerLayout(NormalLayout):
 
     @cached_property
     def middle_text(self) -> str:
-        """Rules text applied at middle stage."""
-        return self.leveler_match[4] if self.leveler_match else ''
+        """Rules text applied at middle stage. Returns a space for empty abilities so they render properly"""
+        if self.leveler_match:
+            if self.leveler_match[4] == '':
+                return ' '
+            return self.leveler_match[4]
+        return ''
 
     @cached_property
     def bottom_level(self) -> str:


### PR DESCRIPTION
Leveler regex pattern would fail to match or have incorrect groups on cards with empty level abilities (Lighthouse Chronologist) and cards with newlines in level abilities (Kargan Dragonlord). This fix replaces the pattern with one that handles these cases. In the case of an empty ability, the group now contains an empty string. The leveler template will still need to be changed for the placeholder text not to show up on cards with empty level abilities.