### PR TITLE
Assign Saga layout to Saga Creature cards

### DIFF
--- a/src/cards.py
+++ b/src/cards.py
@@ -208,11 +208,17 @@ def process_card_data(data: dict, card: CardDetails) -> dict:
     if 'Mutate' in data.get('keywords', []):
         data['layout'] = 'mutate'
         return data
+    
+    type_line = data.get('type_line', '')
 
     # Add Planeswalker layout
-    if 'Planeswalker' in data.get('type_line', ''):
+    if 'Planeswalker' in type_line:
         data['layout'] = 'planeswalker'
         return data
+    
+    # Check for Saga Creature layout
+    if 'Saga' in type_line and 'Creature' in type_line:
+        data['layout'] = 'saga'
 
     # Return updated data
     return data


### PR DESCRIPTION
Currently Saga Creatures, such as `Summon: Shiva`, get the normal layout assigned to them, but they should get the saga layout, which this pull request remedies.