### PR TITLE
Fix Saga and Class layouts' text when reminder text removal is on

### DIFF
--- a/src/layouts.py
+++ b/src/layouts.py
@@ -1191,12 +1191,16 @@ class ClassLayout(NormalLayout):
     @cached_property
     def class_text(self) -> str:
         """Text comprised of class ability lines."""
-        return strip_lines(self.oracle_text, 1)
+        return (
+            self.oracle_text
+            if CFG.remove_reminder
+            else strip_lines(self.oracle_text, 1)
+        )
 
     @cached_property
     def class_description(self) -> str:
         """Description at the top of the Class card."""
-        return get_line(self.oracle_text, 0)
+        return "" if CFG.remove_reminder else get_line(self.oracle_text, 0)
 
     @cached_property
     def class_lines(self) -> list[dict]:

--- a/src/layouts.py
+++ b/src/layouts.py
@@ -1144,12 +1144,16 @@ class SagaLayout(NormalLayout):
     @cached_property
     def saga_text(self) -> str:
         """Text comprised of saga ability lines."""
-        return strip_lines(self.oracle_text, 1)
+        return (
+            self.oracle_text
+            if CFG.remove_reminder
+            else strip_lines(self.oracle_text, 1)
+        )
 
     @cached_property
     def saga_description(self) -> str:
         """Description at the top of the Saga card"""
-        return get_line(self.oracle_text, 0)
+        return "" if CFG.remove_reminder else get_line(self.oracle_text, 0)
 
     @cached_property
     def saga_lines(self) -> list[dict]:


### PR DESCRIPTION
Saga and Class layouts' text processing depends on the number of leading lines, but it doesn't take into account that the first line might have been removed as a result of reminder text removal, which e.g. in Saga's case leads to the first chapter's text going to `saga_description` and `saga_lines` missing that first chapter. This pull request aims to fix this.