### PR TITLE
Add support for Saga creatures

### DIFF
--- a/src/cards.py
+++ b/src/cards.py
@@ -208,11 +208,17 @@ def process_card_data(data: dict, card: CardDetails) -> dict:
     if 'Mutate' in data.get('keywords', []):
         data['layout'] = 'mutate'
         return data
+    
+    type_line = data.get('type_line', '')
 
     # Add Planeswalker layout
-    if 'Planeswalker' in data.get('type_line', ''):
+    if 'Planeswalker' in type_line:
         data['layout'] = 'planeswalker'
         return data
+    
+    # Check for Saga Creature layout
+    if 'Saga' in type_line and 'Creature' in type_line:
+        data['layout'] = 'saga'
 
     # Return updated data
     return data

--- a/src/layouts.py
+++ b/src/layouts.py
@@ -1191,12 +1191,16 @@ class ClassLayout(NormalLayout):
     @cached_property
     def class_text(self) -> str:
         """Text comprised of class ability lines."""
-        return strip_lines(self.oracle_text, 1)
+        return (
+            self.oracle_text
+            if CFG.remove_reminder
+            else strip_lines(self.oracle_text, 1)
+        )
 
     @cached_property
     def class_description(self) -> str:
         """Description at the top of the Class card."""
-        return get_line(self.oracle_text, 0)
+        return "" if CFG.remove_reminder else get_line(self.oracle_text, 0)
 
     @cached_property
     def class_lines(self) -> list[dict]:

--- a/src/layouts.py
+++ b/src/layouts.py
@@ -1174,7 +1174,10 @@ class SagaLayout(NormalLayout):
     @cached_property
     def saga_description(self) -> str:
         """Description at the top of the Saga card"""
-        return "" if CFG.remove_reminder else get_line(self.oracle_text, 0)
+        if CFG.remove_reminder:
+            return ""
+        line = get_line(self.oracle_text, 0)
+        return "" if self._chapter_regex.match(line) else line
 
     @cached_property
     def saga_lines(self) -> list[dict]:

--- a/src/layouts.py
+++ b/src/layouts.py
@@ -3,6 +3,7 @@
 """
 # Standard Library Imports
 from datetime import date, datetime
+import re
 from typing import Optional, Match, Union, Type, ForwardRef
 from os import path as osp
 from pathlib import Path
@@ -1128,6 +1129,8 @@ class SagaLayout(NormalLayout):
     """Saga card layout, introduced in Dominaria."""
     card_class: str = LayoutType.Saga
 
+    _chapter_regex = re.compile(r"^[ ,IVXLCDM]+ — ")
+
     """
     * Bool Properties
     """
@@ -1143,12 +1146,30 @@ class SagaLayout(NormalLayout):
 
     @cached_property
     def saga_text(self) -> str:
-        """Text comprised of saga ability lines."""
-        return (
-            self.oracle_text
-            if CFG.remove_reminder
-            else strip_lines(self.oracle_text, 1)
+        """Text comprised of Saga ability lines."""
+        return "\n".join(
+            (
+                text
+                for text in self.oracle_text.splitlines()
+                if self._chapter_regex.match(text)
+            )
         )
+    
+    @cached_property
+    def ability_text(self) -> str:
+        """
+        Rules text that's separate from the Saga chapters.
+        Seen e.g. in Saga creatures.
+        """
+        # Drop reminder text or first chapter text. Which was dropped
+        # doesn't matter as long as there's at least one chapter.
+        stripped = strip_lines(self.oracle_text, 1)
+        # Return all text that comes after chapter lines.
+        lines = stripped.splitlines()
+        for idx, line in enumerate(lines):
+            if not self._chapter_regex.match(line):
+                return "\n".join(lines[idx:])
+        return ""
 
     @cached_property
     def saga_description(self) -> str:

--- a/src/layouts.py
+++ b/src/layouts.py
@@ -1144,12 +1144,16 @@ class SagaLayout(NormalLayout):
     @cached_property
     def saga_text(self) -> str:
         """Text comprised of saga ability lines."""
-        return strip_lines(self.oracle_text, 1)
+        return (
+            self.oracle_text
+            if CFG.remove_reminder
+            else strip_lines(self.oracle_text, 1)
+        )
 
     @cached_property
     def saga_description(self) -> str:
         """Description at the top of the Saga card"""
-        return get_line(self.oracle_text, 0)
+        return "" if CFG.remove_reminder else get_line(self.oracle_text, 0)
 
     @cached_property
     def saga_lines(self) -> list[dict]:


### PR DESCRIPTION
Assigns Saga layout to Saga creatures and adds rules text processing for Saga creatures. Additionally fixes reminder text removal for Saga and Class layouts.

This is a continuation of #101 and #106.