### PR TITLE
Update pyproject.toml: Bump python version to 3.11+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ Sponsor = "https://patreon.com/mpcfill"
 include = 'src/../'
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.13"
+python = ">=3.11,<3.13"
 photoshop-python-api = "^0.22.4"
 requests = "^2.28.1"
 asynckivy = "^0.7.0"


### PR DESCRIPTION
Both proxyshop code and some dependencies require python 3.11 in order to run, the pytproject.toml incorrectly specifies 3.10+ which will cause the software to not start if a user tries to run it with 3.10