### PR TITLE
Refactor Split template related code

### DIFF
--- a/src/enums/mtg.py
+++ b/src/enums/mtg.py
@@ -374,6 +374,7 @@ class CardTextPatterns:
 
     # Text - Reminder
     TEXT_REMINDER: re.Pattern = re.compile(r"\([^()]*\)")
+    TEXT_REMINDER_ENDING = re.compile(r"[\s\S]*(\([^()]*\))$", )
 
     # Text - Italicised Ability
     TEXT_ABILITY: re.Pattern = re.compile(r"(?:^|\r)+(?:• )*([^\r]+) — ", re.MULTILINE)

--- a/src/layouts.py
+++ b/src/layouts.py
@@ -1249,7 +1249,6 @@ class SplitLayout(NormalLayout):
     is_creature: bool = False
     is_legendary: bool = False
     is_companion: bool = False
-    is_colorless: bool = False
     toughness: str = ''
     power: str = ''
 
@@ -1263,26 +1262,34 @@ class SplitLayout(NormalLayout):
     """
 
     @cached_property
-    def art_file(self) -> list[Path]:
+    def art_file(self) -> Path:
+        return self.art_files[0]
+
+    @cached_property
+    def art_files(self) -> list[Path]:
         """list[Path]: Two image files, second is appended during render process."""
-        return [self.file['file']]
+        return [Path(self.file['file'])]
 
     @cached_property
     def display_name(self) -> str:
         """Both side names."""
-        return f"{self.name[0]} // {self.name[1]}"
+        return f"{self.names[0]} // {self.names[1]}"
 
     @cached_property
-    def card(self) -> list[dict]:
+    def card(self) -> dict:
+        return self.cards[0]
+
+    @cached_property
+    def cards(self) -> list[dict]:
         """Both side objects."""
-        return [c for c in self.scryfall.get('card_faces', [])]
+        return [*self.scryfall.get('card_faces', [])]
 
     """
     * Colors
     """
 
     @cached_property
-    def color_identity(self) -> list:
+    def color_identity(self) -> list[str]:
         """Color identity is shared by both halves, use raw Scryfall instead of 'card' data."""
         return self.scryfall.get('color_identity', [])
 
@@ -1325,10 +1332,14 @@ class SplitLayout(NormalLayout):
     """
 
     @cached_property
-    def watermark(self) -> list[Optional[str]]:
+    def watermark(self) -> str | None:
+        return self.watermarks[0]
+    
+    @cached_property
+    def watermarks(self) -> list[str | None]:
         """Name of the card's watermark file that is actually used, if provided."""
         watermarks: list[Optional[str]] = []
-        for wm in self.watermark_svg:
+        for wm in self.watermark_svgs:
             if not wm:
                 watermarks.append(None)
             elif wm.stem.upper() == 'WM':
@@ -1338,12 +1349,20 @@ class SplitLayout(NormalLayout):
         return watermarks
 
     @cached_property
-    def watermark_raw(self) -> list[Optional[str]]:
+    def watermark_raw(self) -> str | None:
+        return self.watermarks_raw[0]
+    
+    @cached_property
+    def watermarks_raw(self) -> list[str | None]:
         """Name of the card's watermark from raw Scryfall data, if provided."""
-        return [c.get('watermark', '') for c in self.card]
+        return [c.get('watermark', '') for c in self.cards]
+    
+    @cached_property
+    def watermark_svg(self) -> Path | None:
+        return self.watermark_svgs[0]
 
     @cached_property
-    def watermark_svg(self) -> list[Optional[Path]]:
+    def watermark_svgs(self) -> list[Path | None]:
         """Path to the watermark SVG file, if provided."""
         def _find_watermark_svg(wm: str) -> Optional[Path]:
             """Try to find a watermark SVG asset, allowing for special cases and set code fallbacks.
@@ -1372,7 +1391,7 @@ class SplitLayout(NormalLayout):
 
         # Find a watermark SVG for each face
         watermarks = []
-        for w in self.watermark_raw:
+        for w in self.watermarks_raw:
             if CFG.watermark_mode == WatermarkMode.Disabled:
                 # Disabled Mode
                 watermarks.append(None)
@@ -1400,90 +1419,154 @@ class SplitLayout(NormalLayout):
     """
 
     @cached_property
-    def name(self) -> list[str]:
+    def name(self) -> str:
+        return self.names[0]
+
+    @cached_property
+    def names(self) -> list[str]:
         """Both side names."""
         if self.is_alt_lang:
-            return [c.get('printed_name', c.get('name', '')) for c in self.card]
-        return [c.get('name', '') for c in self.card]
+            return [c.get('printed_name', c.get('name', '')) for c in self.cards]
+        return [c.get('name', '') for c in self.cards]
 
     @cached_property
     def name_raw(self) -> str:
         """Sanitized card name to use for rendered image file."""
         return f"{self.name[0]} _ {self.name[1]}"
+    
+    @cached_property
+    def type_line(self) -> str:
+        return self.type_lines[0]
 
     @cached_property
-    def type_line(self) -> list[str]:
+    def type_lines(self) -> list[str]:
         """Both side type lines."""
         if self.is_alt_lang:
-            return [c.get('printed_type_line', c.get('type_line', '')) for c in self.card]
-        return [c.get('type_line', '') for c in self.card]
+            return [c.get('printed_type_line', c.get('type_line', '')) for c in self.cards]
+        return [c.get('type_line', '') for c in self.cards]
+    
+    @cached_property
+    def mana_cost(self) -> str:
+        return self.mana_costs[0]
 
     @cached_property
-    def mana_cost(self) -> list[str]:
+    def mana_costs(self) -> list[str]:
         """Both side mana costs."""
-        return [c.get('mana_cost', '') for c in self.card]
+        return [c.get('mana_cost', '') for c in self.cards]
+    
+    @cached_property
+    def oracle_text(self) -> str:
+        return self.oracle_texts[0]
 
     @cached_property
-    def oracle_text(self) -> list[str]:
+    def oracle_texts(self) -> list[str]:
         """Both side oracle texts."""
         text = []
         for t in [
             c.get('printed_text', c.get('oracle_text', ''))
             if self.is_alt_lang else c.get('oracle_text', '')
-            for c in self.card
+            for c in self.cards
         ]:
-            # Remove Fuse if present in oracle text data
-            t = ''.join(t.split('\n')[:-1]) if 'Fuse' in self.keywords else t
+            if 'Fuse' in self.keywords:
+                # Remove Fuse if present in oracle text data
+                t = ''.join(t.split('\n')[:-1])
+            elif self.shared_reminder:
+                # Remove shared reminder if present
+                t = t[0:-len(self.shared_reminder)].rstrip()
+
             text.append(t)
         return text
+    
+    @cached_property
+    def flavor_text(self) -> str:
+        return self.flavor_texts[0]
 
     @cached_property
-    def flavor_text(self) -> list[str]:
+    def flavor_texts(self) -> list[str]:
         """Both sides flavor text."""
-        return [c.get('flavor_text', '') for c in self.card]
+        return [c.get('flavor_text', '') for c in self.cards]
+    
+    @cached_property
+    def shared_reminder(self) -> str:
+        prev_match: str = ""
+        for oracle_text in [
+            c.get('printed_text', c.get('oracle_text', ''))
+            if self.is_alt_lang else c.get('oracle_text', '')
+            for c in self.cards
+        ]:
+            match = CardTextPatterns.TEXT_REMINDER_ENDING.match(oracle_text)
+            curr_match = match.group(1) if match else ""
+            if not match or (prev_match and prev_match != curr_match):
+                return ""
+            prev_match = curr_match
+        return prev_match
 
     """
     * Bool Data
     """
 
     @cached_property
-    def is_hybrid(self) -> list[bool]:
+    def is_hybrid(self) -> bool:
+        return self.hybrid_checks[0]
+    
+    @cached_property
+    def hybrid_checks(self) -> list[bool]:
         """Both sides hybrid check."""
-        return [f['is_hybrid'] for f in self.frame]
+        return [f['is_hybrid'] for f in self.frames]
 
     @cached_property
-    def is_colorless(self) -> list[bool]:
+    def is_colorless(self) -> bool:
+        return self.colorless_checks[0]
+    
+    @cached_property
+    def colorless_checks(self) -> list[bool]:
         """Both sides colorless check."""
-        return [f['is_colorless'] for f in self.frame]
+        return [f['is_colorless'] for f in self.frames]
 
     """
     * Frame Details
     """
-
+    
     @cached_property
-    def frame(self) -> list[FrameDetails]:
+    def frames(self) -> list[FrameDetails]:
         """Both sides frame data."""
-        return [get_frame_details(c) for c in self.card]
+        return [get_frame_details(c) for c in self.cards]
 
     @cached_property
-    def pinlines(self) -> list[str]:
+    def pinlines(self) -> str:
+        return get_ordered_colors(self.color_identity)
+    
+    @cached_property
+    def pinline_identities(self) -> list[str]:
         """Both sides pinlines identity."""
-        return [f['pinlines'] for f in self.frame]
+        return [f['pinlines'] for f in self.frames]
 
     @cached_property
-    def twins(self) -> list[str]:
+    def twins(self) -> str:
+        return self.pinlines
+    
+    @cached_property
+    def twins_identities(self) -> list[str]:
         """Both sides twins identity."""
-        return [f['twins'] for f in self.frame]
+        return [f['twins'] for f in self.frames]
 
     @cached_property
-    def background(self) -> list[str]:
+    def background(self) -> str:
+        return self.pinlines
+    
+    @cached_property
+    def backgrounds(self) -> list[str]:
         """Both sides background identity."""
-        return [f['background'] for f in self.frame]
+        return [f['background'] for f in self.frames]
 
     @cached_property
-    def identity(self) -> list[str]:
+    def identity(self) -> str:
+        return self.pinlines
+    
+    @cached_property
+    def identities(self) -> list[str]:
         """Both sides frame accurate color identity."""
-        return [f['identity'] for f in self.frame]
+        return [f['identity'] for f in self.frames]
 
 
 class TokenLayout(NormalLayout):

--- a/src/templates/split.py
+++ b/src/templates/split.py
@@ -1,368 +1,456 @@
 """
 * Templates: Split
 """
-# Standard Library Imports
+
+from _ctypes import COMError
 from functools import cached_property
 from pathlib import Path
-from typing import Union, Optional
+from typing import Callable
 
-# Third Party Imports
 from omnitils.strings import normalize_str
-from photoshop.api import ElementPlacement, SolidColor, BlendMode
+from photoshop.api import BlendMode, ElementPlacement, SolidColor
 from photoshop.api._artlayer import ArtLayer
 from photoshop.api._layerSet import LayerSet
 
-# Local Imports
-from src import CFG, CON, ENV
-from src.enums.layers import LAYERS
 import src.helpers as psd
+from src import CFG, CON
+from src.enums.layers import LAYERS
 from src.helpers import LayerEffects
+from src.helpers.colors import GradientConfig
+from src.helpers.effects import copy_layer_fx
+from src.helpers.layers import get_reference_layer
 from src.layouts import SplitLayout
 from src.schema.adobe import EffectColorOverlay, EffectGradientOverlay
-from src.schema.colors import GradientColor
+from src.schema.colors import ColorObject, GradientColor
 from src.templates import BaseTemplate
-from src.text_layers import FormattedTextField, FormattedTextArea, ScaledTextField
+from src.text_layers import FormattedTextArea, FormattedTextField, ScaledTextField
 from src.utils.adobe import ReferenceLayer
 
-"""
-* Template Classes
-"""
 
-
-class SplitTemplate(BaseTemplate):
+class SplitMod(BaseTemplate):
     """
-    * A template for split cards introduced in Invasion.
+    * A modifier class for split cards introduced in Invasion.
 
-    Adds:
-        * Must return all properties shared by both halves as a list of two items (left, right).
-        * Must overwrite a lot of core functionality to navigate rendering 2 cards in one template.
-
-    Todo:
-        * Formalize as a vector template, implement 'Modifier' class.
-    """
-    is_vehicle = False
-    is_artifact = False
-
-    # Color and gradient maps
-    fuse_gradient_locations = {
-        **CON.gradient_locations.copy(),
-        2: [.50, .54],
-        3: [.28, .33, .71, .76],
-        4: [.28, .33, .50, .54, .71, .76]
-    }
-    pinline_gradient_locations = [
-        {**CON.gradient_locations.copy(), 2: [.28, .33]},
-        {**CON.gradient_locations.copy(), 2: [.71, .76]}
-    ]
-
-    def __init__(self, layout: SplitLayout, **kwargs):
-        super().__init__(layout, **kwargs)
-
-    """
-    * Mixin Methods
+    Adds for each side:
+        * Art
+        * Text fields
+        * Color definitions
     """
 
-    @property
-    def post_text_methods(self):
-        """Rotate card sideways."""
-        return [*super().post_text_methods, psd.rotate_counter_clockwise]
+    sides: list[str] = [LAYERS.LEFT, LAYERS.RIGHT]
 
-    """
-    * Bool Properties
-    """
+    # refion Color maps
 
     @cached_property
-    def is_centered(self) -> list[bool]:
-        """Allow centered text for each side independently."""
+    def fuse_gradient_locations(self) -> dict[int, list[int | float]]:
+        return {
+            **CON.gradient_locations,
+            2: [0.50, 0.54],
+            3: [0.28, 0.33, 0.71, 0.76],
+            4: [0.28, 0.33, 0.50, 0.54, 0.71, 0.76],
+        }
+
+    @cached_property
+    def pinline_gradient_locations(self) -> list[dict[int, list[int | float]]]:
         return [
-            bool(
-                len(self.layout.flavor_text[i]) <= 1
-                and len(self.layout.oracle_text[i]) <= 70
-                and "\n" not in self.layout.oracle_text[i]
-            ) for i in range(2)
+            {**CON.gradient_locations, 2: [0.28, 0.33]},
+            {**CON.gradient_locations, 2: [0.71, 0.76]},
         ]
 
-    @cached_property
-    def is_fuse(self) -> bool:
-        """Determine if this is a 'Fuse' split card."""
-        return bool('Fuse' in self.layout.keywords)
+    # endregion Color maps
 
-    """
-    * Colors
-    """
+    # region Settings
 
     @cached_property
     def color_limit(self) -> int:
         """One more than the max number of colors this card can split by."""
-        return 3
+        setting = CFG.get_setting(
+            section="COLORS", key="Max.Colors", default="2", is_bool=False
+        )
+        if isinstance(setting, str):
+            return int(setting) + 1
+        raise ValueError(f"Received invalid value for color limit: {setting}")
+
+    # endregion Settings
+
+    # region Checks
+
+    @cached_property
+    def is_split(self) -> bool:
+        return isinstance(self.layout, SplitLayout)
+
+    @cached_property
+    def text_centerings(self) -> list[bool]:
+        """Allow centered text for each side independently."""
+        if isinstance(self.layout, SplitLayout):
+            return [
+                bool(
+                    len(self.layout.flavor_texts[i]) <= 1
+                    and len(self.layout.oracle_texts[i]) <= 70
+                    and "\n" not in self.layout.oracle_texts[i]
+                )
+                for i in range(len(self.sides))
+            ]
+        return []
+
+    @cached_property
+    def is_fuse(self) -> bool:
+        """Determine if this is a 'Fuse' split card."""
+        return bool("Fuse" in self.layout.keywords)
+
+    @cached_property
+    def has_unified_typeline(self) -> bool:
+        """Determine if the card has only one shared typeline."""
+        if isinstance(self.layout, SplitLayout):
+            return " Room" in self.layout.type_line
+        return False
+
+    # endregion Checks
+
+    # region Mixin methods
+
+    @cached_property
+    def frame_layer_methods(self) -> list[Callable[[], None]]:
+        methods = super().frame_layer_methods
+        if self.is_split:
+            methods.append(self.frame_layers_split)
+        return methods
+
+    @cached_property
+    def post_text_methods(self) -> list[Callable[[], None]]:
+        """Rotate card sideways."""
+        methods = super().post_text_methods
+        if self.is_split:
+            methods.append(psd.rotate_counter_clockwise)
+        return methods
+
+    # endregion Mixin methods
+
+    # region Colors
 
     @cached_property
     def fuse_pinlines(self) -> str:
         """Merged pinline colors of each side."""
-        if self.pinlines[0] != self.pinlines[1]:
-            return self.pinlines[0] + self.pinlines[1]
-        return self.pinlines[0]
+        if isinstance(self.layout, SplitLayout):
+            if self.layout.pinline_identities[0] != self.layout.pinline_identities[1]:
+                return (
+                    self.layout.pinline_identities[0]
+                    + self.layout.pinline_identities[1]
+                )
+            return self.layout.pinline_identities[0]
+        raise NotImplementedError("Fuse colors doesn't support this layout.")
 
     @cached_property
     def fuse_textbox_colors(self) -> str:
-        """Gold if Fuse colors are more than 3, otherwise use Fuse colors."""
-        if len(self.fuse_pinlines) > 3:
+        """Gold if Fuse colors are more than color_limit, otherwise use Fuse colors."""
+        if len(self.fuse_pinlines) > self.color_limit:
             return LAYERS.GOLD
         return self.fuse_pinlines
 
     @cached_property
-    def fuse_pinline_colors(self) -> Union[list[int], list[dict]]:
+    def fuse_pinline_colors(
+        self,
+    ) -> ColorObject | list[ColorObject] | list[GradientConfig]:
         """Color definition for Fuse pinlines."""
         return psd.get_pinline_gradient(
-            self.fuse_pinlines, location_map=self.fuse_gradient_locations)
+            self.fuse_pinlines, location_map=self.fuse_gradient_locations
+        )
 
     @cached_property
-    def fuse_pinlines_action(self) -> Union[psd.create_color_layer, psd.create_gradient_layer]:
-        """Action used to render Fuse pinlines."""
-        return psd.create_color_layer if isinstance(
-            self.fuse_pinline_colors, SolidColor
-        ) else psd.create_gradient_layer
-
-    @cached_property
-    def pinlines_colors(self) -> list[Union[list[int], list[dict]]]:
+    def pinlines_colors_split(
+        self,
+    ) -> list[(ColorObject | list[ColorObject] | list[GradientConfig])]:
         """Color definitions used for pinlines of each side."""
-        return [
-            psd.get_pinline_gradient(p, location_map=self.pinline_gradient_locations[i])
-            for i, p in enumerate(self.pinlines)]
+        if isinstance(self.layout, SplitLayout):
+            return [
+                psd.get_pinline_gradient(
+                    p, location_map=self.pinline_gradient_locations[i]
+                )
+                for i, p in enumerate(self.layout.pinline_identities)
+            ]
+        return []
+
+    # endregion Colors
+
+    # region Groups
 
     @cached_property
-    def pinlines_action(self) -> list[Union[psd.create_color_layer, psd.create_gradient_layer]]:
-        """Action used to render the pinlines of each side."""
-        return [
-            psd.create_color_layer if isinstance(
-                colors, SolidColor
-            ) else psd.create_gradient_layer
-            for colors in self.pinlines_colors]
-
-    """
-    * Layer Groups
-    """
-
-    @cached_property
-    def fuse_group(self) -> Optional[LayerSet]:
+    def fuse_group(self) -> LayerSet | None:
         """Fuse elements parent group."""
-        return psd.getLayerSet('Fuse')
+        return psd.getLayerSet("Fuse")
 
     @cached_property
-    def fuse_textbox_group(self) -> Optional[LayerSet]:
+    def fuse_textbox_group(self) -> LayerSet | None:
         """Fuse textbox group."""
         return psd.getLayerSet(LAYERS.TEXTBOX, self.fuse_group)
 
     @cached_property
-    def fuse_pinlines_group(self) -> Optional[LayerSet]:
+    def fuse_pinlines_group(self) -> LayerSet | None:
         """Fuse pinlines group."""
         return psd.getLayerSet(LAYERS.PINLINES, self.fuse_group)
 
     @cached_property
-    def text_group(self) -> Optional[LayerSet]:
-        """One text and icons group located in the 'Left' side group."""
-        return psd.getLayerSet(LAYERS.TEXT_AND_ICONS, LAYERS.LEFT)
+    def text_groups(self) -> list[LayerSet | None]:
+        """Text and icons group for each side."""
+        return [psd.getLayerSet(LAYERS.TEXT_AND_ICONS, side) for side in self.sides]
 
     @cached_property
-    def card_groups(self):
+    def card_groups(self) -> list[LayerSet | None]:
         """Left and Right side parent groups."""
-        return [
-            psd.getLayerSet(LAYERS.LEFT),
-            psd.getLayerSet(LAYERS.RIGHT)
-        ]
+        return [psd.getLayerSet(side) for side in self.sides]
 
     @cached_property
-    def pinlines_groups(self) -> list[LayerSet]:
+    def pinlines_groups_split(self) -> list[LayerSet | None]:
         """Pinlines group for each side."""
         return [psd.getLayerSet(LAYERS.PINLINES, group) for group in self.card_groups]
 
     @cached_property
-    def twins_groups(self) -> list[LayerSet]:
+    def twins_groups(self) -> list[LayerSet | None]:
         """Twins group for each side."""
         return [psd.getLayerSet(LAYERS.TWINS, group) for group in self.card_groups]
 
     @cached_property
-    def textbox_groups(self) -> list[LayerSet]:
+    def textbox_groups(self) -> list[LayerSet | None]:
         """Textbox group for each side."""
         return [psd.getLayerSet(LAYERS.TEXTBOX, group) for group in self.card_groups]
 
     @cached_property
-    def background_groups(self) -> list[LayerSet]:
+    def background_groups(self) -> list[LayerSet | None]:
         """Background group for each side."""
         return [psd.getLayerSet(LAYERS.BACKGROUND, group) for group in self.card_groups]
 
-    """
-    * References
-    """
+    # endregion Groups
+
+    # region Reference layers
 
     @cached_property
-    def textbox_reference(self) -> list[ArtLayer]:
+    def name_references(self) -> list[ReferenceLayer | None]:
+        """Name reference for each side."""
+        return [ReferenceLayer(layer) for layer in self.text_layers_mana]
+
+    @cached_property
+    def type_references(self) -> list[ReferenceLayer | None]:
+        """Typeline reference for each side."""
+        return self.expansion_references
+
+    @cached_property
+    def expansion_reference(self) -> ArtLayer | None:
+        if self.is_split:
+            return self.expansion_references[-1 if self.has_unified_typeline else 0]
+        return super().expansion_reference
+
+    @cached_property
+    def expansion_references(self) -> list[ReferenceLayer | None]:
+        """Expansion symbol reference for each side."""
+        return [
+            get_reference_layer(LAYERS.EXPANSION_REFERENCE, group)
+            for group in self.text_groups
+        ]
+
+    @cached_property
+    def textbox_references(self) -> list[ReferenceLayer | None]:
         """Textbox positioning reference for each side."""
         return [
             psd.get_reference_layer(
-                LAYERS.TEXTBOX_REFERENCE + ' Fuse' if self.is_fuse else LAYERS.TEXTBOX_REFERENCE,
-                psd.getLayerSet(LAYERS.TEXT_AND_ICONS, group)
-            ) for group in self.card_groups]
+                LAYERS.TEXTBOX_REFERENCE + " Fuse"
+                if self.is_fuse
+                else LAYERS.TEXTBOX_REFERENCE,
+                psd.getLayerSet(LAYERS.TEXT_AND_ICONS, group),
+            )
+            for group in self.card_groups
+        ]
 
     @cached_property
-    def name_reference(self) -> list[ArtLayer]:
-        """list[ArtLayer]: Name reference for each side."""
-        return self.text_layer_name
-
-    @cached_property
-    def type_reference(self) -> list[ArtLayer]:
-        """list[ArtLayer]: Typeline reference for each side."""
-        return [
-            n or self.expansion_reference[i]
-            for i, n in enumerate(self.expansion_symbols)]
-
-    @cached_property
-    def twins_reference(self) -> list[ArtLayer]:
-        """Twins positioning reference for each side."""
-        return [psd.getLayer('Reference', [group, LAYERS.TWINS]) for group in self.card_groups]
-
-    @cached_property
-    def background_reference(self) -> list[ArtLayer]:
+    def background_reference(self) -> list[ArtLayer | None]:
         """Background positioning reference for each side."""
-        return [psd.getLayer('Reference', [group, LAYERS.BACKGROUND]) for group in self.card_groups]
+        return [
+            psd.getLayer("Reference", [group, LAYERS.BACKGROUND])
+            for group in self.card_groups
+        ]
 
     @cached_property
-    def art_reference(self) -> list[ArtLayer]:
+    def art_references(self) -> list[ReferenceLayer | None]:
         """Art layer positioning reference for each side."""
-        return [psd.getLayer(LAYERS.ART_FRAME, group) for group in self.card_groups]
+        return [
+            get_reference_layer(LAYERS.ART_FRAME, group) for group in self.card_groups
+        ]
 
-    """
-    * Text Layers
-    """
+    # endregion Reference layers
 
-    @cached_property
-    def text_layer_name(self) -> list[ArtLayer]:
-        """Name text layer for each side."""
-        return [psd.getLayer(LAYERS.NAME, [self.card_groups[i], LAYERS.TEXT_AND_ICONS]) for i in range(2)]
+    # region Shape layers
 
     @cached_property
-    def text_layer_rules(self) -> list[ArtLayer]:
-        """Rules text layer for each side."""
-        return [psd.getLayer(LAYERS.RULES_TEXT, [self.card_groups[i], LAYERS.TEXT_AND_ICONS]) for i in range(2)]
-
-    @cached_property
-    def text_layer_type(self) -> list[ArtLayer]:
-        """Typeline text layer for each side."""
-        return [psd.getLayer(LAYERS.TYPE_LINE, [self.card_groups[i], LAYERS.TEXT_AND_ICONS]) for i in range(2)]
-
-    @cached_property
-    def text_layer_mana(self) -> list[ArtLayer]:
-        """Mana cost text layer for each side."""
-        return [psd.getLayer(LAYERS.MANA_COST, [self.card_groups[i], LAYERS.TEXT_AND_ICONS]) for i in range(2)]
-
-    """
-    * Expansion Symbol
-    """
-
-    @cached_property
-    def expansion_references(self) -> list[ArtLayer]:
-        """Expansion reference for each side."""
-        return [self.expansion_reference, self.expansion_reference_right]
-
-    @cached_property
-    def expansion_reference_right(self) -> None:
-        """Right side expansion symbol reference."""
-        return psd.getLayer(LAYERS.EXPANSION_REFERENCE, [LAYERS.RIGHT, LAYERS.TEXT_AND_ICONS])
-
-    @cached_property
-    def expansion_symbols(self) -> list[Optional[ArtLayer]]:
-        """Expansion symbol layers for each side. Right side is generated duplicating the left side."""
-        if self.expansion_symbol_layer:
-            layer = self.expansion_symbol_layer.duplicate(self.expansion_reference_right, ElementPlacement.PlaceAfter)
-            psd.align_right(layer, self.expansion_reference_right)
-            return [self.expansion_symbol_layer, layer]
-        return [None, None]
-
-    """
-    * Layers
-    """
-
-    @cached_property
-    def art_layer(self) -> list[ArtLayer]:
+    def art_layers(self) -> list[ArtLayer | None]:
         """Art layer for each side."""
         return [psd.getLayer(LAYERS.DEFAULT, group) for group in self.card_groups]
 
     @cached_property
-    def background_layer(self) -> list[ArtLayer]:
-        """Background layer for each side."""
-        return [psd.getLayer(b, LAYERS.BACKGROUND) for b in self.background]
+    def rules_text_dividers(self) -> list[ArtLayer | None]:
+        """Divider layer for each side."""
+        return [None] * len(self.sides)
+
+    # endregion Shape layers
+
+    # region Text layers
 
     @cached_property
-    def twins_layer(self) -> list[ArtLayer]:
-        """Twins layer for each side."""
-        return [psd.getLayer(t, LAYERS.TWINS) for t in self.twins]
+    def text_layers_name(self) -> list[ArtLayer | None]:
+        """Name text layer for each side."""
+        return [psd.getLayer(LAYERS.NAME, [group]) for group in self.text_groups]
 
     @cached_property
-    def textbox_layer(self) -> list[ArtLayer]:
-        """Textbox layer for each side."""
-        return [psd.getLayer(t, LAYERS.TEXTBOX) for t in self.pinlines]
+    def text_layers_rules(self) -> list[ArtLayer | None]:
+        """Rules text layer for each side."""
+        return [psd.getLayer(LAYERS.RULES_TEXT, [group]) for group in self.text_groups]
 
     @cached_property
-    def divider_layer(self) -> list[Optional[ArtLayer]]:
-        """Divider layer for each side. List updated if either side has flavor text."""
-        return [None, None]
-
-    """
-    * Blending Masks
-    """
+    def text_layers_type(self) -> list[ArtLayer | None]:
+        """Typeline text layer for each side."""
+        return [psd.getLayer(LAYERS.TYPE_LINE, [group]) for group in self.text_groups]
 
     @cached_property
-    def mask_layers(self) -> list[ArtLayer]:
-        """Blending masks supported by this template."""
-        return [psd.getLayer(LAYERS.HALF, LAYERS.MASKS)]
+    def text_layers_mana(self) -> list[ArtLayer | None]:
+        """Mana cost text layer for each side."""
+        return [psd.getLayer(LAYERS.MANA_COST, [group]) for group in self.text_groups]
 
-    """
-    * Watermarks
-    """
+    # endregion Text layers
+
+    # region Expansion Symbol
+
+    def load_expansion_symbol(self) -> None:
+        super().load_expansion_symbol()
+        if self.is_split:
+            self.expansion_symbols
 
     @cached_property
-    def watermark_colors(self) -> list[list[SolidColor]]:
+    def expansion_symbols(self) -> list[ArtLayer | None]:
+        """Expansion symbol layer for each side."""
+        if not self.has_unified_typeline and self.expansion_symbol_layer:
+            symbols: list[ArtLayer | None] = [self.expansion_symbol_layer]
+            for layer_ref in self.expansion_references[1:]:
+                if layer_ref:
+                    symbol_duplicate = self.expansion_symbol_layer.duplicate(
+                        layer_ref, ElementPlacement.PlaceAfter
+                    )
+                    psd.align_right(symbol_duplicate, layer_ref)
+                    try:
+                        copy_layer_fx(self.expansion_symbol_layer, symbol_duplicate)
+                    except COMError:
+                        pass
+                    symbols.append(symbol_duplicate)
+                else:
+                    symbols.append(None)
+            return symbols
+        return [self.expansion_symbol_layer]
+
+    # endregion Expansion Symbol
+
+    # region Artwork
+
+    def load_artwork(
+        self,
+        art_file: str | Path | None = None,
+        art_layer: ArtLayer | None = None,
+        art_reference: ReferenceLayer | None = None,
+    ) -> None:
+        if not self.is_fullart and self.is_split:
+            return self.load_artworks([art_file] if art_file else None)
+        else:
+            return super().load_artwork(art_file, art_layer, art_reference)
+
+    def load_artworks(
+        self,
+        art_files: list[str | Path] | None = None,
+        art_layers: list[ArtLayer | None] | None = None,
+        art_references: list[ReferenceLayer | None] | None = None,
+    ) -> None:
+        """Loads art for each side."""
+
+        if isinstance(self.layout, SplitLayout):
+            # Set default values
+            art_files = art_files or [*self.layout.art_files]
+            art_layers = art_layers or self.art_layers
+            art_references = art_references or self.art_references
+
+            # Second art not provided
+            if len(art_files) == 1:
+                # Manually select a second art
+                self.console.update("Please select the second split art!")
+                file: list[str] = self.app.openDialog()
+                if not file:
+                    self.console.update("No art selected, cancelling render.")
+                    self.console.cancel_thread(thr=self.event)
+                    return
+
+                # Place new art in the correct order
+                if normalize_str(self.layout.names[0]) == normalize_str(
+                    self.layout.file["name"]
+                ):
+                    art_files.append(file[0])
+                else:
+                    art_files.insert(0, file[0])
+
+            # Load art for each side
+            for i, (art_file, layer, ref) in enumerate(
+                zip(art_files, art_layers, art_references)
+            ):
+                if art_file and layer and ref:
+                    super().load_artwork(
+                        art_file=art_files[i],
+                        art_layer=art_layers[i],
+                        art_reference=ref,
+                    )
+
+    # endregion Artwork
+
+    # region Watermarks
+
+    @cached_property
+    def watermarks_colors(self) -> list[list[SolidColor | list[int]]]:
         """A list of 'SolidColor' objects for each face."""
-        colors = []
-        for i, pinline in enumerate(self.pinlines):
-            if pinline in self.watermark_color_map:
-                # Named pinline colors
-                colors.append([self.watermark_color_map.get(pinline, self.RGB_WHITE)])
-            elif len(self.identity[i]) < 3:
-                # Dual color based on identity
-                colors.append([
-                    self.watermark_color_map.get(c, self.RGB_WHITE)
-                    for c in self.identity[i]])
-            else:
-                colors.append([])
-        return colors
+        if isinstance(self.layout, SplitLayout):
+            colors: list[list[SolidColor | list[int]]] = []
+            for i, pinline in enumerate(self.layout.pinline_identities):
+                if pinline in self.watermark_color_map:
+                    # Named pinline colors
+                    colors.append(
+                        [self.watermark_color_map.get(pinline, self.RGB_WHITE)]
+                    )
+                elif len(self.identity[i]) < self.color_limit:
+                    # Dual color based on identity
+                    colors.append(
+                        [
+                            self.watermark_color_map.get(c, self.RGB_WHITE)
+                            for c in self.identity[i]
+                        ]
+                    )
+                else:
+                    colors.append([])
+        raise NotImplementedError("Watermarks colors doesn't support this layout.")
 
     @cached_property
-    def watermark_fx(self) -> list[list[LayerEffects]]:
+    def watermark_fxs(self) -> list[list[LayerEffects]]:
         """A list of LayerEffects' objects for each face."""
         fx: list[list[LayerEffects]] = []
-        for color in self.watermark_colors:
+        for color in self.watermarks_colors:
             if len(color) == 1:
                 # Single color watermark
-                fx.append([EffectColorOverlay(
-                    opacity=100,
-                    color=color[0]
-                )])
+                fx.append([EffectColorOverlay(opacity=100, color=color[0])])
             elif len(color) == 2:
                 # Dual color watermark
-                fx.append([EffectGradientOverlay(
-                    rotation=0,
-                    colors=[
-                        GradientColor(
-                            color=color[0],
-                            location=0,
-                            midpoint=50),
-                        GradientColor(
-                            color=color[1],
-                            location=4096,
-                            midpoint=50)
+                fx.append(
+                    [
+                        EffectGradientOverlay(
+                            rotation=0,
+                            colors=[
+                                GradientColor(color=color[0], location=0, midpoint=50),
+                                GradientColor(
+                                    color=color[1], location=4096, midpoint=50
+                                ),
+                            ],
+                        )
                     ]
-                )])
+                )
             else:
                 fx.append([])
         return fx
@@ -370,174 +458,230 @@ class SplitTemplate(BaseTemplate):
     def create_watermark(self) -> None:
         """Render a watermark for each side that has one."""
 
-        # Add watermark to each side if needed
-        for i, watermark in enumerate(self.layout.watermark):
+        if isinstance(self.layout, SplitLayout):
+            # Add watermark to each side if needed
+            for i, watermark in enumerate(self.layout.watermarks):
+                # Required values to generate a Watermark
+                if (
+                    watermark
+                    and (mark := self.layout.watermark_svgs[i])
+                    and (textbox_ref := self.textbox_references[i])
+                ):
+                    # Get watermark custom settings if available
+                    wm_details = CON.watermarks.get(watermark, {})
 
-            # Required values to generate a Watermark
-            if not all([
-                self.layout.watermark_svg[i],
-                self.textbox_reference[i],
-                self.watermark_colors[i],
-                watermark
-            ]):
-                return
+                    # Import and frame the watermark
+                    wm = psd.import_svg(
+                        path=mark,
+                        ref=textbox_ref,
+                        placement=ElementPlacement.PlaceAfter,
+                        docref=self.docref,
+                    )
+                    psd.frame_layer(
+                        layer=wm,
+                        ref=textbox_ref,
+                        smallest=True,
+                        scale=wm_details.get("scale", 80),
+                    )
 
-            # Get watermark custom settings if available
-            wm_details = CON.watermarks.get(watermark, {})
+                    # Apply opacity, blending, and effects
+                    wm.opacity = wm_details.get("opacity", CFG.watermark_opacity)
+                    wm.blendMode = BlendMode.ColorBurn
+                    psd.apply_fx(wm, self.watermark_fxs[i])
+        else:
+            return super().create_watermark()
 
-            # Import and frame the watermark
-            wm = psd.import_svg(
-                path=self.layout.watermark_svg[i],
-                ref=self.textbox_reference[i],
-                placement=ElementPlacement.PlaceAfter,
-                docref=self.docref)
-            psd.frame_layer(
-                layer=wm,
-                ref=self.textbox_reference[i],
-                smallest=True,
-                scale=wm_details.get('scale', 80))
+    # endregion Watermarks
 
-            # Apply opacity, blending, and effects
-            wm.opacity = wm_details.get('opacity', CFG.watermark_opacity)
-            wm.blendMode = BlendMode.ColorBurn
-            psd.apply_fx(wm, self.watermark_fx[i])
+    # region Frame layer methods
 
-    """
-    * Loading Files
-    """
+    def frame_layers_split(self) -> None:
+        """Enable frame layers required by Split cards. None by default."""
+        pass
 
-    def load_artwork(
-        self,
-        art_file: Optional[str | Path | list[str | Path]] = None,
-        art_layer: Optional[list[ArtLayer]] = None,
-        art_reference: Optional[list[ReferenceLayer]] = None
-    ) -> None:
-        """Loads the specified art file into the specified layer.
+    # endregion Frame layer methods
 
-        Args:
-            art_file: Optional path (as str or Path) to art file. Will use `self.layout.art_file`
-                if not provided.
-            art_layer: Optional `ArtLayer` where art image should be placed when imported. Will use `self.art_layer`
-                property if not provided.
-            art_reference: Optional `ReferenceLayer` that should be used to position and scale the imported
-                image. Will use `self.art_reference` property if not provided.`
-        """
-
-        # Set default values
-        art_file = art_file or self.layout.art_file
-        art_layer = art_layer or self.art_layer
-        art_reference = art_reference or self.art_reference
-
-        # Double up art for test mode
-        if ENV.TEST_MODE and not isinstance(art_file, list):
-            art_file = [art_file] * 2
-
-        # Second art not provided
-        if len(art_file) == 1:
-
-            # Manually select a second art
-            self.console.update("Please select the second split art!")
-            file = self.app.openDialog()
-            if not file:
-                self.console.update('No art selected, cancelling render.')
-                self.console.cancel_thread(thr=self.event)
-                return
-
-            # Place new art in the correct order
-            if normalize_str(self.layout.name[0]) == normalize_str(self.layout.file['name']):
-                art_file.append(file[0])
-            else:
-                art_file.insert(0, file[0])
-
-        # Load art for each side
-        for i, ref in enumerate(art_reference):
-            super().load_artwork(
-                art_file=art_file[i],
-                art_layer=art_layer[i],
-                art_reference=ref)
-
-    """
-    * Frame Layer Methods
-    """
-
-    def enable_frame_layers(self) -> None:
-        """Enable frame layers for each side. Add Fuse layers if required."""
-
-        # Frame layers
-        for i in range(2):
-            # Copy twins and position
-            self.twins_layer[i].visible = True
-            twins = self.twins_layer[i].parent.duplicate(self.twins_groups[i], ElementPlacement.PlaceBefore)
-            self.twins_layer[i].visible = False
-            twins.visible = True
-            psd.align_horizontal(twins, self.twins_reference[i])
-
-            # Copy background and position
-            background = self.background_layer[i].duplicate(
-                self.background_groups[i], ElementPlacement.PlaceInside)
-            background.visible = True
-            psd.align_horizontal(background, self.background_reference[i])
-
-            # Copy textbox and position
-            textbox = self.textbox_layer[i].duplicate(
-                self.textbox_groups[i], ElementPlacement.PlaceInside)
-            textbox.visible = True
-            self.active_layer = textbox
-            psd.align_horizontal(textbox, self.textbox_reference[i].dims)
-            if self.is_fuse:
-                psd.select_bounds(self.textbox_reference[i].bounds, self.doc_selection)
-                self.doc_selection.invert()
-                self.doc_selection.clear()
-            self.doc_selection.deselect()
-
-            # Apply pinlines
-            self.generate_layer(
-                group=self.pinlines_groups[i],
-                colors=self.pinlines_colors[i])
-
-        # Fuse addone
-        if self.is_fuse:
-            psd.getLayer(f'{LAYERS.BORDER} Fuse').visible = True
-            self.fuse_group.visible = True
-            self.generate_layer(
-                group=self.fuse_pinlines_group,
-                colors=self.fuse_pinline_colors)
-            self.generate_layer(
-                group=self.fuse_textbox_group,
-                colors=self.fuse_textbox_colors,
-                masks=self.mask_layers)
-
-    """
-    * Text Layer Methods
-    """
+    # region Text layer methods
 
     def basic_text_layers(self) -> None:
         """Add basic text layers for each side."""
-        for i in range(2):
-            self.text.extend([
-                FormattedTextField(
-                    layer=self.text_layer_mana[i],
-                    contents=self.layout.mana_cost[i]
-                ),
-                ScaledTextField(
-                    layer=self.text_layer_name[i],
-                    contents=self.layout.name[i],
-                    reference=self.name_reference[i]
-                ),
-                ScaledTextField(
-                    layer=self.text_layer_type[i],
-                    contents=self.layout.type_line[i],
-                    reference=self.type_reference[i]
-                )])
+        if isinstance(self.layout, SplitLayout):
+            for i in range(len(self.sides)):
+                if (name := self.text_layers_name[i]) and (
+                    mana := self.text_layers_mana[i]
+                ):
+                    self.text.extend(
+                        [
+                            FormattedTextField(
+                                layer=mana,
+                                contents=self.layout.mana_costs[i],
+                            ),
+                            ScaledTextField(
+                                layer=name,
+                                contents=self.layout.names[i],
+                                reference=self.name_references[i],
+                            ),
+                        ]
+                    )
+
+                if (not self.has_unified_typeline or i == 0) and (
+                    layer := self.text_layers_type[i]
+                ):
+                    self.text.append(
+                        ScaledTextField(
+                            layer=layer,
+                            contents=self.layout.type_lines[i],
+                            reference=self.type_references[
+                                -1 if self.has_unified_typeline else i
+                            ],
+                        )
+                    )
+        else:
+            return super().basic_text_layers()
 
     def rules_text_and_pt_layers(self) -> None:
-        """Add rules and P/T text for each face."""
-        for i in range(2):
-            self.text.append(
-                FormattedTextArea(
-                    layer=self.text_layer_rules[i],
-                    contents=self.layout.oracle_text[i],
-                    flavor=self.layout.flavor_text[i],
-                    reference=self.textbox_reference[i],
-                    divider=self.divider_layer[i],
-                    centered=self.is_centered[i]))
+        """Add rules and P/T text for each side."""
+        if isinstance(self.layout, SplitLayout):
+            for i in range(len(self.sides)):
+                if layer := self.text_layers_rules[i]:
+                    self.text.append(
+                        FormattedTextArea(
+                            layer=layer,
+                            contents=self.layout.oracle_texts[i],
+                            flavor=self.layout.flavor_texts[i],
+                            reference=self.textbox_references[i],
+                            divider=self.rules_text_dividers[i],
+                            centered=self.text_centerings[i],
+                        )
+                    )
+        else:
+            return super().rules_text_and_pt_layers()
+
+    # endregion Text layer methods
+
+
+class SplitTemplate(SplitMod):
+    """
+    * A template for split cards.
+
+    In addition to SplitMod, adds for each side:
+        * Frame layers
+    """
+
+    # region Reference layers
+
+    @cached_property
+    def twins_references(self) -> list[ArtLayer | None]:
+        """Twins positioning reference for each side."""
+        return [
+            psd.getLayer("Reference", [group, LAYERS.TWINS])
+            for group in self.card_groups
+        ]
+
+    # endregion Reference layers
+
+    # region Shape layers
+
+    @cached_property
+    def background_layers(self) -> list[ArtLayer | None]:
+        """Background layer for each side."""
+        if isinstance(self.layout, SplitLayout):
+            return [psd.getLayer(b, LAYERS.BACKGROUND) for b in self.layout.backgrounds]
+        return [None] * len(self.sides)
+
+    @cached_property
+    def twins_layers(self) -> list[ArtLayer | None]:
+        """Twins layer for each side."""
+        if isinstance(self.layout, SplitLayout):
+            return [psd.getLayer(t, LAYERS.TWINS) for t in self.layout.twins_identities]
+        return [None] * len(self.sides)
+
+    @cached_property
+    def textbox_layers(self) -> list[ArtLayer | None]:
+        """Textbox layer for each side."""
+        if isinstance(self.layout, SplitLayout):
+            return [
+                psd.getLayer(t, LAYERS.TEXTBOX) for t in self.layout.pinline_identities
+            ]
+        return [None] * len(self.sides)
+
+    # endregion Shape layers
+
+    # region Blending masks
+
+    @cached_property
+    def mask_layers(self) -> list[ArtLayer]:
+        """Blending masks supported by this template."""
+        if self.is_split:
+            if layer := psd.getLayer(LAYERS.HALF, LAYERS.MASKS):
+                return [layer]
+            return []
+        return super().mask_layers
+
+    # endregion Blending masks
+
+    # region Frame layer methods
+
+    def frame_layers_split(self) -> None:
+        """Enable frame layers for each side. Add Fuse layers if required."""
+
+        # Frame layers
+        for i in range(len(self.sides)):
+            if (group := self.twins_groups[i]) and (layer := self.twins_layers[i]):
+                # Copy twins and position
+                layer.visible = True
+                twins = layer.parent.duplicate(group, ElementPlacement.PlaceBefore)
+                layer.visible = False
+                twins.visible = True
+
+                if ref := self.twins_references[i]:
+                    psd.align_horizontal(twins, ref)
+
+            if layer := self.background_layers[i]:
+                # Copy background and position
+                background = layer.duplicate(
+                    self.background_groups[i], ElementPlacement.PlaceInside
+                )
+                background.visible = True
+
+                if ref := self.background_reference[i]:
+                    psd.align_horizontal(background, ref)
+
+            if layer := self.textbox_layers[i]:
+                # Copy textbox and position
+                textbox = layer.duplicate(
+                    self.textbox_groups[i], ElementPlacement.PlaceInside
+                )
+                textbox.visible = True
+
+                if ref := self.textbox_references[i]:
+                    self.active_layer = textbox
+                    psd.align_horizontal(textbox, ref.dims)
+                    if self.is_fuse:
+                        psd.select_bounds(ref.bounds, self.doc_selection)
+                        self.doc_selection.invert()
+                        self.doc_selection.clear()
+                    self.doc_selection.deselect()
+
+            if group := self.pinlines_groups_split[i]:
+                # Apply pinlines
+                self.generate_layer(group=group, colors=self.pinlines_colors_split[i])
+
+        # Fuse addon
+        if self.is_fuse:
+            if layer := psd.getLayer(f"{LAYERS.BORDER} Fuse"):
+                layer.visible = True
+            if self.fuse_group:
+                self.fuse_group.visible = True
+            if self.fuse_pinlines_group:
+                self.generate_layer(
+                    group=self.fuse_pinlines_group, colors=self.fuse_pinline_colors
+                )
+            if self.fuse_textbox_group:
+                self.generate_layer(
+                    group=self.fuse_textbox_group,
+                    colors=self.fuse_textbox_colors,
+                    masks=self.mask_layers,
+                )
+
+    # endregion Frame layer methods


### PR DESCRIPTION
Depends on #96 because of type annotations.

Changes:  
- Refactors Split template and layout so that they inherit their base classes in a type safe way, i.e. so that they don't change the types of the base classes' properties and functions. This aims to improve the code base's compatibility with static type checking.
- Adds rudimentary support for unified typeline when rendering Split cards, but does not add the required functionality and frame elements to the current normal Split template. This is relevant currently only for Room cards.
- Adds a `SplitMod` class, which aims to provide basic Split rendering logic for inheriting classes.

I have done limited testing, i.e. checked that a regular and a fuse card still render correctly with the normal Split template, so it's still quite likely that there are bugs in the code.

Please let me know if you'd like some bigger or smaller changes to the approach taken here.