### PR TITLE
Show all category tabs irrespective of the amount of templates

### DIFF
--- a/src/gui/tabs/main.py
+++ b/src/gui/tabs/main.py
@@ -58,10 +58,6 @@ class TemplateModule(DynamicTabPanel, GlobalAccess):
             # Get the template map for this category
             templates: TemplateCategoryMap = self.main.template_map[cat]
 
-            # If less than 2 templates exist for this category, skip it
-            if len(templates['names']) < 2:
-                continue
-
             # Add a tab for this category
             tab = DynamicTabItem(text=cat)
             tab.content = self.get_template_container(


### PR DESCRIPTION
Shows all category tabs irrespective of the amount of templates available for each category. This allows users to easily see whether they have some template installed that can render a certain type of card or not, without having to try to render a card of that type. This also makes it easier to see all the different card types that Proxyshop has support for.