### PR TITLE
Add an option to open Scryfall data in a text editor for manual modification

### DIFF
--- a/src/_config.py
+++ b/src/_config.py
@@ -48,6 +48,8 @@ class AppConfig:
         self.scry_ascending = self.file.getboolean('APP.DATA', 'Scryfall.Ascending', fallback=False)
         self.scry_extras = self.file.getboolean('APP.DATA', 'Scryfall.Extras', fallback=False)
         self.scry_unique = self.get_option('APP.DATA', 'Scryfall.Unique', ScryfallUnique)
+        self.manually_edit_card_data = self.file.getboolean('APP.DATA', 'Manually.Edit.Card.Data', fallback=False)
+        self.manual_text_editor = self.file.get('APP.DATA', 'Manual.Text.Editor', fallback='notepad "{}"')
 
         # APP - TEXT
         self.force_english_formatting = self.file.getboolean('APP.TEXT', "Force.English.Formatting", fallback=False)
@@ -87,7 +89,7 @@ class AppConfig:
     * Setting Utils
     """
 
-    def get_option(self, section: str, key: str, enum_class: type[StrConstant], default: str = None) -> str:
+    def get_option(self, section: str, key: str, enum_class: type[StrConstant], default: str | None = None) -> str:
         """Returns the current value of an "options" setting if that option exists in its StrEnum class.
         Otherwise, returns the default value of that StrEnum class.
 
@@ -100,14 +102,14 @@ class AppConfig:
         Returns:
             Validated current value, or default value.
         """
-        default = default or enum_class.Default
+        defa = default or enum_class.Default
         if self.file.has_section(section):
-            option = self.file[section].get(key, fallback=default)
+            option = self.file[section].get(key, fallback=defa)
             if option in enum_class:
                 return option
-        return default
+        return defa
 
-    def get_setting(self, section: str, key: str, default: Optional[str] = None, is_bool: bool = True):
+    def get_setting(self, section: str, key: str, default: str | bool | None = None, is_bool: bool = True):
         """Check if the setting exists and return it. Default will be returned if missing.
 
         Args:

--- a/src/data/config/app.toml
+++ b/src/data/config/app.toml
@@ -70,6 +70,18 @@ type = "options"
 default = "arts"
 options = ["arts", "prints"]
 
+[DATA."Manually.Edit.Card.Data"]
+title = "Manually Edit Card Data"
+desc = """At the start of the render process, will pass the Scryfall data to a text editor for manual modification. Save the file and close the editor to proceed. This can be used, e.g., to fix incorrect Scryfall data or for creating custom cards."""
+type = "bool"
+default = 0
+
+[DATA."Manual.Text.Editor"]
+title = "Manual Text Editor"
+desc = """Text editor to use for the manual card data editing step. Add curly brackets {} where you wish for the file path to be slotted in the command, e.g. Visual Studio Code can be used with [b]C:\\full\\path\\to\\Code.exe -w "{}"[/b]."""
+type = "string"
+default = 'notepad "{}"'
+
 ###
 # * Text Settings
 ###

--- a/src/layouts.py
+++ b/src/layouts.py
@@ -3,7 +3,7 @@
 """
 # Standard Library Imports
 from datetime import date, datetime
-from typing import Optional, Match, Union, Type, ForwardRef
+from typing import Optional, Match, Union, Type
 from os import path as osp
 from pathlib import Path
 from functools import cached_property
@@ -16,6 +16,7 @@ from src import CFG, CON, CONSOLE, ENV, PATH
 from src.cards import CardDetails, FrameDetails, get_card_data, parse_card_info, process_card_data
 from src.console import msg_error, msg_success
 from src.utils.hexapi import get_watermark_svg, get_watermark_svg_from_set
+from src.utils.manual_actions import manually_modify_dict
 from src.utils.scryfall import get_cards_oracle
 from src.enums.layers import LAYERS
 from src.enums.mtg import (
@@ -40,7 +41,7 @@ from src.frame_logic import (
 """
 
 
-def assign_layout(filename: Path) -> str | ForwardRef('CardLayout'):
+def assign_layout(filename: Path) -> "str | CardLayout":
     """Assign layout object to a card.
 
     Args:
@@ -65,6 +66,14 @@ def assign_layout(filename: Path) -> str | ForwardRef('CardLayout'):
     scryfall = get_card_data(card, cfg=CFG, logger=CONSOLE)
     if not scryfall:
         return msg_error(name_failed, reason="Scryfall search failed")
+    
+    if CFG.get_setting('BASE.TEMPLATES', 'Manually.Edit.Card.Data', default=False):
+        try:
+            scryfall = manually_modify_dict(scryfall, CFG.manual_text_editor)
+        except Exception as e:
+            CONSOLE.log_exception(e)
+            return msg_error(name_failed, reason="Manual card data modification failed")
+
     scryfall = process_card_data(scryfall, card)
 
     # Instantiate layout object

--- a/src/layouts.py
+++ b/src/layouts.py
@@ -67,7 +67,7 @@ def assign_layout(filename: Path) -> "str | CardLayout":
     if not scryfall:
         return msg_error(name_failed, reason="Scryfall search failed")
     
-    if CFG.get_setting('BASE.TEMPLATES', 'Manually.Edit.Card.Data', default=False):
+    if CFG.manually_edit_card_data:
         try:
             scryfall = manually_modify_dict(scryfall, CFG.manual_text_editor)
         except Exception as e:

--- a/src/utils/manual_actions.py
+++ b/src/utils/manual_actions.py
@@ -1,0 +1,24 @@
+from json import dump, load
+from os import unlink
+import subprocess
+from tempfile import NamedTemporaryFile
+from typing import Any
+
+
+def manually_modify_dict(
+    data: dict[str, Any], text_editing_program: str = 'notepad "{}"'
+) -> dict[str, Any]:
+    tmp = NamedTemporaryFile(
+        "w",
+        prefix="Proxyshop_manual_dict_modification_",
+        encoding="UTF-8",
+        delete=False,
+    )
+    try:
+        dump(data, tmp, ensure_ascii=False, indent=2)
+        tmp.close()
+        subprocess.run((text_editing_program.format(tmp.name)), check=True)
+        with open(tmp.name, "r", encoding="UTF-8") as f:
+            return load(f)
+    finally:
+        unlink(tmp.name)


### PR DESCRIPTION
Adds an option to open Scryfall card data in a text editor at the beginning of the render process, which allows, e.g., to fix incorrect data or to create custom cards. The user can supply the text editor program they wish to use via the settings.